### PR TITLE
feat: adds dimiss keyboard within tap gesture

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# What type of MR is this? (check all aplicable)
+- [] 🔄 Refactor
+- [] 🎁 Feature
+- [] 🐛 Bug Fix
+- [] 🔥 Optimization
+- [] ✅ Test
+- [] 📝 Documentation Update
+- [] 🎨 Style
+- [] ⏪ Revert 
+- [] 💡 POC 
+- [] 🤔 Other: _add description here_
+
+# Description
+
+## Device:
+
+## How it has been tested:
+
+- Action(s)
+- Expected result(s)
+
+# Added/updated Tests?
+- [] 🫡 Yes, unit tests
+- [] 📲 Yes, Snapshot tests
+- [] 🙅‍♂️ No, and this is why: UITesting needs to be written
+- [] 🙋‍♂️ I need help to write Tests
+
+# Screenshots
+| Expected/Before | After (Smallest Screen) | After  (Biggest Screen)|
+| ------ | ------ | ------ | 

--- a/ProtocolsApp/ApplyDiscount/ApplyDiscountView.swift
+++ b/ProtocolsApp/ApplyDiscount/ApplyDiscountView.swift
@@ -96,6 +96,7 @@ final class ApplyDiscountView: UIView {
         buildViewHierarchy()
         setupConstraints()
         setupAdditionalConfiguration()
+        setupTagGestureRecognizer()
     }
 
     required init?(coder: NSCoder) {
@@ -125,6 +126,15 @@ final class ApplyDiscountView: UIView {
     private func setupAdditionalConfiguration() {
         stackView.setCustomSpacing(4, after: valueTextField)
         stackView.setCustomSpacing(40, after: infoLabel)
+    }
+
+    private func setupTagGestureRecognizer() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        addGestureRecognizer(tap)
+    }
+
+    @objc private func dismissKeyboard() {
+        endEditing(true)
     }
 }
 

--- a/ProtocolsApp/ApplyDiscount/ApplyDiscountView.swift
+++ b/ProtocolsApp/ApplyDiscount/ApplyDiscountView.swift
@@ -86,6 +86,7 @@ final class ApplyDiscountView: UIView {
 
     // MARK: - Actions
     @objc func didTapButton() {
+        dismissKeyboard()
         delegate?.applyDiscount(value: valueTextField.text ?? "0")
     }
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Project heavely inspired on [Commitando Youtube channel](https://www.youtube.com
 
 ## TODOs:
 
-- [ ] Usability
-  - [ ] Adds tap gesture to dismiss keyboard when tapping outside of it
+- [x] Usability
+  - [x] Adds tap gesture to dismiss keyboard when tapping outside of it
 - [ ] `ApplyDiscountPresenter`
   - [ ] Apply I and D SOLID principles to NumberFormatter
   - [ ] Refactor unit tests


### PR DESCRIPTION
# What type of MR is this? (check all aplicable)
- [] 🔄 Refactor
- [x] 🎁 Feature
- [] 🐛 Bug Fix
- [] 🔥 Optimization
- [] ✅ Test
- [] 📝 Documentation Update
- [] 🎨 Style
- [] ⏪ Revert 
- [] 💡 POC 
- [] 🤔 Other: _add description here_

# Description
Adds tap gesture recognizer to `ApplyDiscountView` in order to enable numerical keyboard dismissing when the user finishes typing.

## Device:
iPhone 14 Pro Max Simulator

## How it has been tested:
Run the project, then

1. Type some value on the keyboard, then tap on the screen outside of the keyboard. The expected behavior is the keyboard dismissal
2. Type some value on the keyboard, then tap to Apply Discount button. The expected behavior is the keyboard dismissal


# Added/updated Tests?
- [] 🫡 Yes, unit tests
- [] 📲 Yes, Snapshot tests
- [x] 🙅‍♂️ No, and this is why: UITesting needs to be written
- [] 🙋‍♂️ I need help to write Tests

# Screenshots
| Expected/Before | After (Smallest Screen) | After  (Biggest Screen)|
| ------ | ------ | ------ | 


Biggest Screen
https://github.com/r-fsantos/ProtocolsAppExample/assets/21016965/832a4629-6c24-4eba-8074-263d0cb8457e



